### PR TITLE
Update signaling to match spec. Fixes #3.

### DIFF
--- a/examples/Newhaven_OLED_example/Newhaven_OLED_example.ino
+++ b/examples/Newhaven_OLED_example/Newhaven_OLED_example.ino
@@ -36,7 +36,7 @@
    Modified 19 May 2015 by Pasquale D'Antini:
    https://www.newhavendisplay.com/NHD_forum/index.php?topic=914.0
    
-   Further modifications to use "NewhavenOLED" library by Andy4495, Dec 2017 and Jan 2019.
+   Further modifications to use "NewhavenOLED" library by Andy4495, Dec 2017, Jan 2019, July 2024.
 
    This example code is in the public domain.
 */
@@ -128,11 +128,12 @@ void oneAtATime() {
 
 void singleUpdate() {
   char c = '0';
+  oled.clear();
 
   for (int i = 0; i < COLUMN_N; i++) {
     oled.write(COLUMN_N/2, 0, c++);
+    delay(100);
   }
-  delay(100);
 
 }
 // _______________________________________________________________________________________

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NewhavenOLED
-version=1.1.4-rc1
+version=1.1.4
 author=Andreas Taylor <Andy4495@outlook.com>
 maintainer=Andreas Taylor <Andy4495@outlook.com>
 sentence=Library for Newhaven 0216CW and 0220CW OLEDs.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NewhavenOLED
-version=1.1.3
+version=1.1.4-rc1
 author=Andreas Taylor <Andy4495@outlook.com>
 maintainer=Andreas Taylor <Andy4495@outlook.com>
 sentence=Library for Newhaven 0216CW and 0220CW OLEDs.

--- a/src/NewhavenOLED.cpp
+++ b/src/NewhavenOLED.cpp
@@ -76,6 +76,8 @@ void NewhavenOLED::command(byte c)
     digitalWrite(CS_pin, LOW);
   }
 
+  enable_SCK_MOSI();
+
   byte i = 0;                   // Bit index
 
   for (i = 0; i < 5; i++)
@@ -90,6 +92,8 @@ void NewhavenOLED::command(byte c)
   }
 
   send_byte(c);                      // Transmits the byte
+
+  disable_SCK_MOSI();
 
   if (CS_pin != NO_PIN) {
     digitalWrite(CS_pin, HIGH);
@@ -111,6 +115,8 @@ void NewhavenOLED::data(byte d)
     digitalWrite(CS_pin, LOW);
   }
 
+  enable_SCK_MOSI();
+
   byte i = 0;                        // Bit index
 
   for (i = 0; i < 5; i++)
@@ -126,6 +132,8 @@ void NewhavenOLED::data(byte d)
   clock_cycle();
 
   send_byte(d);                      // Transmits the byte
+
+  disable_SCK_MOSI();
 
   if (CS_pin != NO_PIN) {
     digitalWrite(CS_pin, HIGH);
@@ -255,10 +263,8 @@ void NewhavenOLED::begin()
     pinMode(CS_pin, OUTPUT);
     digitalWrite(CS_pin, HIGH);
   }
-  pinMode(MOSI_pin, OUTPUT);
-  digitalWrite(MOSI_pin, LOW);
-  pinMode(SCK_pin, OUTPUT);
-  digitalWrite(SCK_pin, HIGH);
+
+  enable_SCK_MOSI();
 
   cursorC = 0;
   cursorR = 0;
@@ -299,6 +305,9 @@ void NewhavenOLED::begin()
   delay(2);             // After a clear display, a minimum pause of 1-2 ms is required
   command(0x80);        // Set DDRAM address 0x00 in address counter (cursor home) (default value)
   command(0x0C);        // Display ON/OFF control: display ON, cursor off, blink off
+
+  disable_SCK_MOSI();
+
   delay(250);           // Waits 250 ms for stabilization purpose after display on
 }
 
@@ -308,20 +317,15 @@ void NewhavenOLED::begin()
 void NewhavenOLED::end()
 {
   command(0x20 | Row_bit); // RE=0 (exit from extended command set), lines #
-  command(0x08);        // display off, cursor off, blink off (default values)
+  command(0x08);           // display off, cursor off, blink off (default values)
 
-  // Put control pins in default state
-  pinMode(MOSI_pin, OUTPUT);
-  digitalWrite(MOSI_pin, LOW);
-  pinMode(SCK_pin, OUTPUT);
-  digitalWrite(SCK_pin, HIGH);
   if (CS_pin != NO_PIN) {
-    pinMode(CS_pin, OUTPUT);
     digitalWrite(CS_pin, HIGH);
+    pinMode(CS_pin, OUTPUT);
   }
   if (RST_pin != NO_PIN) {
-    pinMode(RST_pin, OUTPUT);
     digitalWrite(RST_pin, HIGH);
+    pinMode(RST_pin, OUTPUT);
   }
 
 }
@@ -340,9 +344,9 @@ void NewhavenOLED::clock_cycle()
   // Note that the Arduino and Energia documentation state that the function
   // is only accurate for values of  3us and greater; hence, the delay below
   // uses 3 us, even though a 1 us delay would be sufficient.
-  digitalWrite(SCK_pin, LOW);        // Sets LOW the SCLK line of the display
+  digitalWrite(SCK_pin, HIGH); 
   delayMicroseconds(3);              // Waits >1 us (required for timing purpose)
-  digitalWrite(SCK_pin, HIGH);       // Sets HIGH the SCLK line of the display
+  digitalWrite(SCK_pin, LOW);
   delayMicroseconds(3);              // Waits >1 us (required for timing purpose)
 }
 
@@ -384,4 +388,15 @@ void NewhavenOLED::send_byte(byte tx_b)
     digitalWrite(MOSI_pin, LOW);
     clock_cycle();
   }
+}
+
+void NewhavenOLED::enable_SCK_MOSI() {
+  pinMode(MOSI_pin, OUTPUT);
+  digitalWrite(SCK_pin, LOW);
+  pinMode(SCK_pin, OUTPUT);
+}
+
+void NewhavenOLED::disable_SCK_MOSI() {
+  pinMode(SCK_pin, INPUT);
+  pinMode(MOSI_pin, INPUT);
 }

--- a/src/NewhavenOLED.h
+++ b/src/NewhavenOLED.h
@@ -55,5 +55,8 @@ private:
   void clock_cycle();
   void send_byte(byte c);
   byte row_address[4];
+  void enable_SCK_MOSI();
+  void disable_SCK_MOSI();
+
 };
 #endif


### PR DESCRIPTION
Update control signals to better match US2066 driver chip: 
- Only enable SCK and MOSI pins when display is being sent control/data
- Reverse SCK logic to toggle low-high-low instead of high-ow-high

Update example so that the single-character-update portion is easier to monitor by clearing display first and adding a small delay between character updates. 